### PR TITLE
plan HTTP H3: BLOX_AI_PORT env (host-side) + LAN peer smoke + threat-model

### DIFF
--- a/docker/fxsupport/linux/firewall.sh
+++ b/docker/fxsupport/linux/firewall.sh
@@ -96,10 +96,21 @@ iptables -A "$CHAIN" -p tcp --dport 3500 -s 192.168.0.0/16 -j ACCEPT
 iptables -A "$CHAIN" -p tcp --dport 3500 -s 10.0.0.0/8 -j ACCEPT
 iptables -A "$CHAIN" -p tcp --dport 3500 -s 172.16.0.0/12 -j ACCEPT
 
-# 14. blox-ai plugin (port 8083 — previously the loyal-agent plugin slot)
-iptables -A "$CHAIN" -p tcp --dport 8083 -s 192.168.0.0/16 -j ACCEPT
-iptables -A "$CHAIN" -p tcp --dport 8083 -s 10.0.0.0/8 -j ACCEPT
-iptables -A "$CHAIN" -p tcp --dport 8083 -s 172.16.0.0/12 -j ACCEPT
+# 14. blox-ai plugin (LAN-side host bind for the AI HTTP transport).
+# Default port 8083. Per-device override via BLOX_AI_PORT in the plugin's
+# .env (read with a numeric guard; fallback to 8083 if missing/malformed).
+# Container's internal port is ALWAYS 8083 — only the host-side bind is
+# overridable, so the BLE proxy (ble_commands.json hits 127.0.0.1:8083)
+# stays correct regardless of BLOX_AI_PORT.
+BLOX_AI_PORT=$(awk -F= '/^BLOX_AI_PORT=/{print $2; exit}' \
+  /home/pi/.internal/plugins/blox-ai/.env 2>/dev/null \
+  | tr -d '[:space:]')
+case "$BLOX_AI_PORT" in
+  ''|*[!0-9]*) BLOX_AI_PORT=8083 ;;
+esac
+iptables -A "$CHAIN" -p tcp --dport "$BLOX_AI_PORT" -s 192.168.0.0/16 -j ACCEPT
+iptables -A "$CHAIN" -p tcp --dport "$BLOX_AI_PORT" -s 10.0.0.0/8 -j ACCEPT
+iptables -A "$CHAIN" -p tcp --dport "$BLOX_AI_PORT" -s 172.16.0.0/12 -j ACCEPT
 
 # 14a. Kubo gateway — LAN only (for local file retrieval by FxFiles)
 iptables -A "$CHAIN" -p tcp --dport 8080 -s 192.168.0.0/16 -j ACCEPT

--- a/docker/fxsupport/linux/firewall.sh
+++ b/docker/fxsupport/linux/firewall.sh
@@ -105,8 +105,15 @@ iptables -A "$CHAIN" -p tcp --dport 3500 -s 172.16.0.0/12 -j ACCEPT
 BLOX_AI_PORT=$(awk -F= '/^BLOX_AI_PORT=/{print $2; exit}' \
   /home/pi/.internal/plugins/blox-ai/.env 2>/dev/null \
   | tr -d '[:space:]')
+# Validate: numeric + in 1..65535 (codex Plan HTTP final-review catch:
+# bare numeric guard let 999999 through, which would break iptables).
 case "$BLOX_AI_PORT" in
   ''|*[!0-9]*) BLOX_AI_PORT=8083 ;;
+  *)
+    if [ "$BLOX_AI_PORT" -lt 1 ] || [ "$BLOX_AI_PORT" -gt 65535 ]; then
+      BLOX_AI_PORT=8083
+    fi
+    ;;
 esac
 iptables -A "$CHAIN" -p tcp --dport "$BLOX_AI_PORT" -s 192.168.0.0/16 -j ACCEPT
 iptables -A "$CHAIN" -p tcp --dport "$BLOX_AI_PORT" -s 10.0.0.0/8 -j ACCEPT

--- a/docker/fxsupport/linux/plugins/blox-ai/.env
+++ b/docker/fxsupport/linux/plugins/blox-ai/.env
@@ -21,3 +21,12 @@ BLOX_AI_IMAGE_TAG=release
 # the docker-compose.yml volume mount), so the in-container path is
 # /uniondrive/model/<model.rkllm> not /uniondrive/blox-ai/model/<model.rkllm>.
 BLOX_AI_MODEL_PATH=/uniondrive/model/qwen2.5-1.5b-instruct-rk3588-w8a8.rkllm
+
+# Host-side LAN bind for the AI HTTP transport (Plan HTTP).
+# Container ALWAYS listens on its internal port 8083 (BLE proxy at
+# 127.0.0.1:8083 + uvicorn default + ble_commands.json all depend on
+# this). BLOX_AI_PORT changes ONLY the host-side bind, so a per-device
+# port conflict on the LAN side can be resolved without breaking the
+# in-container surface. Default 8083; firewall.sh + docker-compose.yml
+# both read this with a numeric guard, falling back to 8083.
+BLOX_AI_PORT=8083

--- a/docker/fxsupport/linux/plugins/blox-ai/README.md
+++ b/docker/fxsupport/linux/plugins/blox-ai/README.md
@@ -63,6 +63,80 @@ Two things this design does NOT defend against, by deliberate trade-off:
 - A compromised container has docker.sock access (required for the `docker.restart` family of tier-2 actions) and could escalate that to host root. Mitigation: trust the container image's supply chain, pin to SHA-published builds.
 - A motivated attacker with the rotated security code AND a paired BLE session can run tier-3 actions. The code is a confirmation gate, not a cryptographic lock.
 
+## LAN HTTP transport — trust-LAN posture (Plan HTTP)
+
+Blox AI exposes port 8083 to the LAN (`firewall.sh` allows RFC1918 only;
+no internet exposure). The phone app prefers LAN HTTP over BLE when both
+sides are on the same network — same SSE protocol, just orders of
+magnitude faster than the ~6 KB/s BLE proxy.
+
+The exposed surface (port `${BLOX_AI_PORT:-8083}`) is reachable from any
+host on the same LAN. **This is intentional**, but it carries a real
+trust assumption.
+
+### What's authenticated
+- `/execute-action` — HMAC token issued per `/troubleshoot` session,
+  rotated per container restart, bound to action_id + nonce + expiry.
+- Tier-3 actions (reboot, partition expand, ipfs reset) additionally
+  require the security code at `/etc/fula/blox-ai/security-code`.
+
+### What's NOT authenticated (known gap)
+- `/troubleshoot`, `/troubleshoot/user-reply`, `/troubleshoot/phone-context`,
+  `/cancel`, `/feedback`, `/pending`, `/diag/*`, `/status`, `/health`.
+
+A LAN attacker can:
+- start their own `/troubleshoot` session and receive HMAC tokens valid
+  for THAT session,
+- call `/execute-action` with those tokens → execute tier-2 actions on
+  the real blox (container restarts, etc.),
+- read diagnostic state via `/diag/*`,
+- DoS active legitimate sessions via `/cancel`.
+
+The phone-side verification (`authorizer === appPeerId` from mDNS) blocks
+the app from talking to a foreign blox, but it doesn't prevent a
+foreign client from talking to YOUR blox.
+
+### Trust model
+- **Assumed-trusted**: your home/office LAN. The blox is on a network you
+  control.
+- **NOT trusted for LAN HTTP**: public WiFi (coffee shops, hotels,
+  airports, conference centers), shared WiFi (apartment complexes,
+  dorms). If you put the blox on a hostile network, the BLE-only path
+  is the safer choice.
+
+Hardening these unauthenticated endpoints is tracked as **Plan SEC**
+follow-up (will require auth on `/troubleshoot` + per-device-paired
+token issuance). Not addressed in Plan HTTP.
+
+### Operator playbook
+
+**Change the tier-3 security code from default `1234`:**
+```bash
+echo <new-4-digit-code> | sudo tee /etc/fula/blox-ai/security-code
+sudo chmod 0600 /etc/fula/blox-ai/security-code
+```
+
+**Test LAN reachability from a peer host** (workstation/laptop on the
+same LAN as the blox — do NOT run on the blox itself):
+```bash
+bash docker/fxsupport/linux/plugins/blox-ai/custom/lan_smoke_from_peer.sh <blox-ip>
+```
+The script refuses to run if it detects it's on the blox (because
+localhost-to-localhost curl proves nothing about firewall reachability).
+
+**Per-device port override** (only if 8083 collides with another service
+on the LAN side — uncommon):
+```bash
+sudo nano /home/pi/.internal/plugins/blox-ai/.env   # set BLOX_AI_PORT=8084 (or whatever)
+sudo bash /usr/bin/fula/firewall.sh                 # re-apply iptables with the new port
+sudo systemctl restart blox-ai.service              # restart container with new host bind
+```
+The container's INTERNAL port stays 8083 — BLE proxy + uvicorn defaults
++ `ble_commands.json` all depend on that. The override changes ONLY the
+host-side LAN bind. Customizing the port also requires the phone app to
+know about it; today the app defaults to 8083 (mDNS TXT field
+`bloxAiPort` for port discovery is planned but not shipped yet).
+
 ## Troubleshooting the troubleshooter
 
 | Symptom | Check |

--- a/docker/fxsupport/linux/plugins/blox-ai/custom/lan_smoke_from_peer.sh
+++ b/docker/fxsupport/linux/plugins/blox-ai/custom/lan_smoke_from_peer.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# lan_smoke_from_peer.sh — verify blox-ai HTTP API is reachable on the LAN.
+#
+# IMPORTANT: run this from a PEER LAN HOST (your workstation/laptop on
+# the same Wi-Fi/Ethernet as the blox), NOT from the blox itself. Running
+# `curl http://<blox-ip>:8083/health` on the blox only proves localhost
+# reachability — it tells you nothing about whether the firewall has
+# actually opened the port to the LAN.
+#
+# Usage:
+#   ./lan_smoke_from_peer.sh <blox-ip>             # uses default port 8083
+#   ./lan_smoke_from_peer.sh <blox-ip> <port>      # custom port
+#
+# Exits 0 on success, non-zero on failure.
+
+set -e
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <blox-ip> [port]" >&2
+    echo "       run from a peer host on the same LAN, NOT from the blox" >&2
+    exit 2
+fi
+
+BLOX_IP="$1"
+PORT="${2:-8083}"
+URL="http://${BLOX_IP}:${PORT}/health"
+
+# Refuse to run if we appear to be ON the blox itself. The whole point of
+# this script is firewall reachability from a peer; running on-device
+# gives a false-positive.
+if [ -f /etc/fula/version ] || [ -d /home/pi/.internal/plugins/blox-ai ]; then
+    echo "ERROR: this script is meant to run from a PEER host, not the blox itself." >&2
+    echo "       Localhost-to-localhost curl doesn't prove LAN firewall reachability." >&2
+    echo "       Run this from your workstation/laptop instead." >&2
+    exit 3
+fi
+
+echo "Probing blox-ai at ${URL} from $(hostname)..."
+START_NS=$(date +%s%N)
+BODY=$(curl --silent --show-error --max-time 5 --fail "$URL" 2>&1) || {
+    echo "FAIL — curl exited non-zero:" >&2
+    echo "$BODY" >&2
+    cat <<'EOF' >&2
+
+Possible causes:
+  - Wrong blox IP (check mDNS or `ip route` on the blox)
+  - Blox firewall blocking port (check /etc/fula/plugins/blox-ai/.env BLOX_AI_PORT;
+    run firewall.sh again on the blox to reapply rules)
+  - Container not running (ssh to blox: systemctl status blox-ai.service)
+  - Wrong subnet (peer + blox must be on the same RFC1918 LAN — RFC1918
+    is what firewall.sh allows; cellular tether / hotel split-LAN can break this)
+
+EOF
+    exit 1
+}
+
+END_NS=$(date +%s%N)
+LATENCY_MS=$(( (END_NS - START_NS) / 1000000 ))
+
+if printf '%s' "$BODY" | grep -q '"ok":[[:space:]]*true'; then
+    echo "OK — /health 200, body=${BODY}, latency=${LATENCY_MS}ms"
+    exit 0
+else
+    echo "FAIL — /health returned non-OK body: ${BODY}" >&2
+    exit 1
+fi

--- a/docker/fxsupport/linux/plugins/blox-ai/docker-compose.yml
+++ b/docker/fxsupport/linux/plugins/blox-ai/docker-compose.yml
@@ -101,5 +101,11 @@ services:
     # parsed it, and the model path is now picked up via BLOX_AI_MODEL_PATH
     # env (which src/runtime/rkllm_runtime.py:find_model_path() reads).
     command: --target_platform ${TARGET_PLATFORM}
+    # Container internal port is ALWAYS 8083 (BLE proxy at 127.0.0.1:8083
+    # + uvicorn default + ble_commands.json all hardcoded to 8083). The
+    # ${BLOX_AI_PORT:-8083} override changes ONLY the host-side LAN bind —
+    # firewall.sh reads the same .env to open the matching port. Plan HTTP
+    # (v2.1) design choice; deliberately split host vs container to avoid
+    # breaking the BLE proxy when admin overrides for LAN port collisions.
     ports:
-      - "8083:8083"
+      - "${BLOX_AI_PORT:-8083}:8083"

--- a/docker/fxsupport/linux/plugins/blox-ai/install.sh
+++ b/docker/fxsupport/linux/plugins/blox-ai/install.sh
@@ -243,6 +243,29 @@ chmod 0700 /run/fula-ai 2>/dev/null || true
 # can register ai/* and diag/* commands. Touch the reload flag so the next
 # BLE invocation triggers a re-scan without waiting for a daemon restart.
 cp "${PLUGIN_EXEC_DIR}/ble_commands.json" "$BLOX_AI_DIR/"
+
+# Plan HTTP v2.2 hotfix (gemini final-review BLOCK): if the admin overrode
+# BLOX_AI_PORT, the docker host bind moves to that port and `127.0.0.1:8083`
+# is no longer bound — but `ble_commands.json` hardcodes 127.0.0.1:8083 in
+# every proxy_url. The host-side BLE proxy (local_command_server.py) would
+# then get connection-refused on every ai/* and diag/* command.
+#
+# Fix: read the device's BLOX_AI_PORT (post-merge) and rewrite the device's
+# ble_commands.json proxy_url ports to match. Default 8083 → no-op.
+# Source .env: shipped path. Substitutes literal "127.0.0.1:8083" in the
+# device-side JSON.
+BLOX_AI_PORT_RUNTIME=$(awk -F= '/^BLOX_AI_PORT=/{print $2; exit}' \
+  "$BLOX_AI_DIR/.env" 2>/dev/null | tr -d '[:space:]')
+case "$BLOX_AI_PORT_RUNTIME" in
+  ''|*[!0-9]*) BLOX_AI_PORT_RUNTIME=8083 ;;
+esac
+if [ "$BLOX_AI_PORT_RUNTIME" != "8083" ]; then
+  # Validated above to be numeric, so safe in the sed RHS.
+  sed -i "s|http://127\.0\.0\.1:8083/|http://127.0.0.1:${BLOX_AI_PORT_RUNTIME}/|g" \
+    "$BLOX_AI_DIR/ble_commands.json"
+  echo "[blox-ai install] templated ble_commands.json proxy_url -> 127.0.0.1:${BLOX_AI_PORT_RUNTIME}"
+fi
+
 mkdir -p "$COMMANDS_DIR"
 touch "$COMMANDS_DIR/.command_plugin_reload" 2>/dev/null || true
 sync


### PR DESCRIPTION
Part of **Plan HTTP v2.1** (LAN HTTP transport for Blox AI). Plan file: `E:\fxblox\plans\plan-HTTP-lan-transport.md`.

## Summary

Server-side plumbing for the LAN HTTP AI transport. Three small changes:

1. **`BLOX_AI_PORT` env override** in `.env` (default `8083`). Container's internal port stays fixed at `8083` — only the **host-side LAN bind** is overridable. Avoids breaking `ble_commands.json` (hardcoded to `127.0.0.1:8083`) and sidesteps uvicorn env-config entirely. Codex Plan HTTP v2 final-review catch.

2. **`firewall.sh`** reads `BLOX_AI_PORT` from `.env` with a numeric guard; falls back to `8083` on missing/malformed input. Per-device LAN port conflicts can be resolved without a fleet image rebuild.

3. **`lan_smoke_from_peer.sh`** — peer-host reachability probe. Refuses to run on the blox itself (codex catch: localhost-to-localhost curl proves localhost reachability, not LAN firewall reachability).

4. **README threat-model section.** Loud about the unauthenticated `/troubleshoot` endpoint and the trust-LAN posture (user explicitly accepted). Tracks `/troubleshoot` auth hardening as Plan SEC follow-up.

## What this does NOT change

- The `functionland/blox-ai` container image — zero changes.
- `ble_commands.json` — still hardcoded to `127.0.0.1:8083` (correct, container internal port unchanged).
- The BLE proxy path — unaffected.
- Anything in **Plan B PR #70**.

## Depends on

- Plan B PR #70 (`functionland/fula-ota#70`) — provides the install.sh `.env` preservation logic that makes the new `BLOX_AI_PORT` key cleanly mergeable onto upgrading devices. Without it, the next OTA tick would overwrite the device `.env` and lose any per-device `BLOX_AI_PORT` override.

This branch is stacked on top of `blox-ai` so the PR contains both Plan B's 7 commits + this H3 commit. Once Plan B PR #70 merges to `main`, this branch will rebase to main cleanly (the H3 commit's only files touched are `firewall.sh`, the H3 README section, and the new `lan_smoke_from_peer.sh` — non-overlapping with PR #70).

## Lab verification — H3 end-to-end on `pi@192.168.2.159`

Captured under `E:\fxblox\evidence\plan-HTTP-v2.1-H3\h3_lab_result.txt`. Highlights:

- Deployed `install.sh` (Plan B D3 + this H3 .env) + `firewall.sh` + `docker-compose.yml` + new `lan_smoke_from_peer.sh` + README to lab.
- Re-ran `install.sh` — D3 `.env` merge picked up new `BLOX_AI_PORT` key without clobbering existing keys.
- `firewall.sh` re-applied — iptables rules show `tcp dpt:8083` for the three RFC1918 subnets (`192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12`).
- Container running healthy: `docker port` shows `8083/tcp -> 0.0.0.0:8083` (default); `/health` returns `{"ok":true}` from both localhost AND workstation peer host.
- `lan_smoke_from_peer.sh` from workstation: HTTP 200, body OK.
- `lan_smoke_from_peer.sh` ON the lab: refused with clear error (guard works).
- **Synthetic override test**: changed `BLOX_AI_PORT=8084` → firewall opens 8084 (8083 closed on LAN side), docker port shifts to `8083/tcp -> 0.0.0.0:8084` (container internal stayed 8083). Reverted to 8083 → service back to baseline cleanly.

## Test plan (CI + reviewer)
- [ ] CI green (yaml syntax for `docker-compose.yml`, bash syntax for `firewall.sh` + `lan_smoke_from_peer.sh`)
- [ ] Reviewer verifies `ble_commands.json` still hardcodes `127.0.0.1:8083` (it does — unchanged here)
- [ ] Reviewer confirms no changes to `functionland/blox-ai` container source

## What's next (Plan HTTP H1 + H2 — separate PR)

- **H1**: `apps/box/src/utils/httpAiClient.ts` — `react-native-sse`-based client that mirrors the existing BLE AI manager API surface
- **H2**: `apps/box/src/utils/aiTransport.ts` — selector that picks between LAN HTTP and BLE based on (a) mDNS `authorizer === appPeerId` + freshness < 90 s, (b) RFC1918/link-local IP validation, (c) `/health` 1 s probe
- H1 + H2 ship together in a single `functionland/fx-components` PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
