### PR TITLE
Fix ipfs-cluster wedge: blox-ai bind-mounts identity.json as a directory

### DIFF
--- a/docker/fxsupport/linux/plugins/blox-ai/docker-compose.yml
+++ b/docker/fxsupport/linux/plugins/blox-ai/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       # vars only need overriding when running the impls on the host
       # directly (smoke tests).
       - BLOX_AI_CONFIG_YAML_PATH=/etc/fula/host-config.yaml
-      - BLOX_AI_CLUSTER_IDENTITY_PATH=/etc/fula/host-ipfs-cluster-identity.json
+      - BLOX_AI_CLUSTER_IDENTITY_PATH=/etc/fula/host-ipfs-cluster/identity.json
       - BLOX_AI_PLUGINS_DIR=/etc/fula/host-plugins
       # diag/kubo_health: reaches kubo via container name on fula_default
       # network (joined below). Host loopback (127.0.0.1:5001) only works
@@ -161,7 +161,21 @@ services:
       # peerID (which is what the chain records — distinct from the
       # kubo peerID the app talks to). The `private_key` field in this
       # file is NOT touched by the impl.
-      - /uniondrive/ipfs-cluster/identity.json:/etc/fula/host-ipfs-cluster-identity.json:ro
+      #
+      # MOUNT THE PARENT DIRECTORY, NOT THE FILE. A direct *file* bind-mount
+      # of identity.json is a footgun: when the host file is absent at
+      # container-create time (a fresh/reformatted /uniondrive, or before
+      # go-fula's `initipfscluster` has written it), the Docker daemon
+      # auto-creates the missing source as an empty ROOT-OWNED DIRECTORY.
+      # That permanently wedges ipfs-cluster — its init loops forever on
+      # `[ -f identity.json ]` ("Waiting for /internal and /uniondrive...")
+      # and go-fula's initipfscluster panics trying to WriteFile over a
+      # directory. Mounting the PARENT means Docker can only ever auto-create
+      # the directory /uniondrive/ipfs-cluster (harmless — that is what it
+      # is), never the file-as-directory. identity_health reads the file via
+      # BLOX_AI_CLUSTER_IDENTITY_PATH=/etc/fula/host-ipfs-cluster/identity.json
+      # (set above), inside this mount.
+      - /uniondrive/ipfs-cluster:/etc/fula/host-ipfs-cluster:ro
       # Phase 0.5c: diag/plugins needs the plugins manifest dir
       # (active-plugins.txt + per-plugin status.txt + info.json).
       # Read-only — diag never mutates plugin state.

--- a/docker/fxsupport/linux/plugins/blox-ai/trees/not-earning.yaml
+++ b/docker/fxsupport/linux/plugins/blox-ai/trees/not-earning.yaml
@@ -80,6 +80,27 @@ nodes:
     diag: identity_health
     timeout_s: 12
     branches:
+      # ipfs-cluster identity.json got created as a DIRECTORY (Docker bind-mount
+      # footgun) — the cluster is "running" but wedged in its init wait-loop, so
+      # the container_check above passed it through. identity_health reports this
+      # precisely (distinct from a legitimately-absent identity). Surface it with
+      # a concrete repair instead of the generic "indeterminate" verdict.
+      - when: "result.pool_member == None and result.pool_member_reason == 'cluster_identity_is_directory'"
+        then:
+          emit_thought: |
+            ipfs-cluster's identity file (/uniondrive/ipfs-cluster/identity.json) is a
+            DIRECTORY, not a file — a Docker bind-mount artifact that wedges the cluster
+            so it never starts and the blox can't earn. Restarting fula clears it
+            (go-fula removes the bogus dir and regenerates the deterministic identity).
+          emit_verdict:
+            summary: "Your Blox's cluster identity got created as a folder instead of a file, so ipfs-cluster can't start — that's why it isn't earning. Restarting your Blox's services repairs it automatically; your cluster ID and earnings are preserved."
+            severity: red
+            root_cause: cluster_identity_is_directory
+          emit_recommendation:
+            action_name: restart_fula
+            tier: 2
+            reasoning: "Restart fula.service so go-fula removes the directory-shaped identity.json and regenerates the deterministic identity, un-wedging ipfs-cluster."
+          stop: true
       - when: "result.pool_member == False"
         then:
           emit_thought: |

--- a/docker/fxsupport/linux/readiness-check.py
+++ b/docker/fxsupport/linux/readiness-check.py
@@ -2533,6 +2533,75 @@ def check_and_fix_ipfs_cluster():
         ipfs_cluster_logs = subprocess.getoutput("sudo docker logs ipfs_cluster --tail 80 2>&1")
         cluster_error_found = False
 
+        # --- identity.json created as a DIRECTORY (Docker bind-mount footgun) ---
+        # A plugin's *file* bind-mount of /uniondrive/ipfs-cluster/identity.json
+        # (blox-ai's diag/identity_health) makes the Docker daemon auto-create the
+        # path as an empty ROOT-OWNED DIRECTORY whenever the real file is absent at
+        # container-create time (fresh/reformatted /uniondrive, or before go-fula's
+        # initipfscluster has written it). That permanently wedges the cluster: its
+        # init loops forever on `[ -f identity.json ]` ("Waiting for /internal and
+        # /uniondrive...") and go-fula's initipfscluster panics trying to WriteFile
+        # over a directory. This emits NO daemon-log error the patterns below match,
+        # so detect the directory directly.
+        #
+        # Recovery: stop blox-ai first so its bind-mount can't recreate the dir,
+        # remove it, then restart fula so go-fula regenerates identity.json. The
+        # regenerated cluster PeerID is DETERMINISTIC (derived from the persistent
+        # identity in /internal/config.yaml), so the on-chain registration — and
+        # therefore earnings — are preserved. Only restart blox-ai once the file is
+        # back, so its (possibly still-old, file-style) bind-mount binds an existing
+        # file and cannot re-create the directory mid-recovery.
+        identity_path = "/uniondrive/ipfs-cluster/identity.json"
+        if os.path.isdir(identity_path):
+            logging.warning("ipfs-cluster identity.json is a DIRECTORY (Docker "
+                            "bind-mount artifact). Removing + restarting fula so it "
+                            "can be regenerated.")
+            try:
+                # Every call carries a timeout so a container wedged in 'D'
+                # (uninterruptible IO wait — common on the flaky storage that
+                # triggers this bug) can never hang the watchdog itself. A
+                # timeout raises TimeoutExpired (NOT CalledProcessError), so
+                # catch both and retry next cycle rather than killing the loop.
+                subprocess.run(["sudo", "systemctl", "stop", "blox-ai.service"],
+                               capture_output=True, timeout=90)
+                subprocess.run(["sudo", "systemctl", "stop", "fula.service"],
+                               capture_output=True, timeout=150, check=True)
+                time.sleep(10)
+                subprocess.run(["sudo", "rm", "-rf", identity_path],
+                               capture_output=True, timeout=60)
+                subprocess.run(["sudo", "sync"], capture_output=True, timeout=60)
+                safe_start_fula(capture_output=True, timeout=150, check=True)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                logging.error("cluster identity.json dir repair: a command failed "
+                              "or timed out (%s); will retry next cycle.", e)
+                return True
+            # go-fula rewrites identity.json during startup. Wait for it to reappear
+            # as a regular FILE before bringing blox-ai back (up to ~180s).
+            identity_restored = False
+            for _ in range(36):
+                time.sleep(5)
+                if os.path.isfile(identity_path):
+                    identity_restored = True
+                    break
+            if identity_restored:
+                try:
+                    subprocess.run(["sudo", "systemctl", "start", "blox-ai.service"],
+                                   capture_output=True, timeout=90)
+                except subprocess.TimeoutExpired:
+                    logging.warning("blox-ai start timed out; it will start on the "
+                                    "next cycle/boot (identity.json is a file, so safe).")
+            else:
+                logging.warning("identity.json not regenerated within timeout; leaving "
+                                "blox-ai stopped to avoid re-creating the directory. It "
+                                "will come back on the next stack start once the file exists.")
+            _append_event("restart", {
+                "unit": "fula.service",
+                "action": "cluster_identity_dir_repair",
+                "remediation": "rm_identity_dir+restart_fula",
+                "identity_restored": identity_restored,
+            })
+            return True
+
         # Empty or unparseable service.json — triggers "unexpected end of JSON input" /
         # "error loading configurations" in the daemon. Root cause is the init-script jq
         # pipeline overwriting service.json with an empty temp file when a filter errors.

--- a/docker/go-fula/go-fula.sh
+++ b/docker/go-fula/go-fula.sh
@@ -343,6 +343,17 @@ while true; do
       log "The initipfs exited with an error: Exit code $exit_code"
     fi
 
+    # Docker bind-mount footgun guard: a plugin's file bind-mount (blox-ai) can
+    # create /uniondrive/ipfs-cluster/identity.json as a DIRECTORY when the real
+    # file is absent at container-create time. initipfscluster would then panic
+    # trying to WriteFile over a directory — and this script has no `set -e`, so
+    # it would touch .ipfscluster_setup anyway and mask the failure. Remove a
+    # directory-shaped identity.json so initipfscluster writes the real
+    # (deterministic) file.
+    if [ -d /uniondrive/ipfs-cluster/identity.json ]; then
+      log "identity.json is a directory (bind-mount artifact); removing before initipfscluster"
+      rm -rf /uniondrive/ipfs-cluster/identity.json
+    fi
     /initipfscluster
     touch /internal/.ipfscluster_setup
 


### PR DESCRIPTION
## Problem
On a blox, `/uniondrive/ipfs-cluster/identity.json` was an empty **directory** instead of a file. `ipfs_cluster` was stuck forever printing `Waiting for /internal and /uniondrive to become available and writable...` and the device could not earn. Neither `fula-readiness-check` nor the blox-ai "not earning" path detected or repaired it.

## Root cause (proven on a lab device)
The **blox-ai plugin bind-mounts the identity FILE directly** (`plugins/blox-ai/docker-compose.yml`):
```
- /uniondrive/ipfs-cluster/identity.json:/etc/fula/host-ipfs-cluster-identity.json:ro
```
When the Docker daemon sets up a bind mount whose host source path is absent, it **auto-creates the source as a root-owned directory**. blox-ai runs as its own systemd service with no ordering dependency on the identity existing, so whenever `identity.json` is absent at blox-ai container-create time (fresh/reformatted `/uniondrive`, or before go-fula writes it), Docker poisons the path. That permanently wedges the cluster (`[ -f identity.json ]` fails forever) and makes go-fula's `initipfscluster` panic (`WriteFile` over a directory); `go-fula.sh` has no `set -e`, so it marks `.ipfscluster_setup` done anyway, masking it.

Reproduced byte-for-byte on the lab device: a `docker run` with that exact mount + absent source created `identity.json` as `drwxr-xr-x root root`. The regenerated cluster peerID is **deterministic** (derived from `/internal/config.yaml`), so recovery preserves the on-chain registration -> earnings resume without re-registration.

## Why the safety nets missed it
- **readiness-check** only matched specific daemon-error log strings; the wait-loop matches none, and a directory `identity.json` was treated as "legitimately absent."
- **not-earning tree** only flagged the cluster if `oom_killed` or `state != running`; the wedged container is `running`, so it fell through to a chain check that couldn't read the peerID -> "indeterminate."

## Changes (this PR, fula-ota)
- **Fix 1 (prevent recurrence)** -- `plugins/blox-ai/docker-compose.yml`: mount the **parent dir** `/uniondrive/ipfs-cluster` instead of the file, and point `BLOX_AI_CLUSTER_IDENTITY_PATH` at `identity.json` inside it. Docker can then only ever auto-create the harmless directory, never the file-as-dir. `identity_health` honors the env var, so no blox-ai image rebuild is needed.
- **Fix 2 (recover already-wedged devices)** -- `readiness-check.py` `check_and_fix_ipfs_cluster()`: detect `os.path.isdir(identity.json)` -> stop blox-ai -> stop fula -> `rm -rf` the dir -> restart fula (go-fula regenerates the deterministic identity) -> restart blox-ai once the file is back. All subprocess calls are timeout-bounded so a D-state container cannot hang the watchdog.
- **Fix 3a (defense)** -- `docker/go-fula/go-fula.sh`: remove a directory-shaped `identity.json` before `initipfscluster`.
- **Fix 4a (detection)** -- `plugins/blox-ai/trees/not-earning.yaml`: branch on the new `cluster_identity_is_directory` reason -> concrete "cluster identity is a folder" verdict + `restart_fula` recommendation instead of "indeterminate."

## Companion PRs
- **go-fula**: `initipfscluster` self-heals a directory-shaped identity.json (Fix 3b).
- **blox-ai**: `identity_health` reports `cluster_identity_is_directory` (Fix 4b) -- Fix 4a's tree branch is inert until this ships.

## Validation (lab device, fxblox-rk1)
- Reproduced the mechanism (Docker creates the dir on real mergerfs).
- Proved deterministic peerID regeneration (file == cluster API == regenerated).
- Full wedge->recover cycle: reproduced the exact wedge, recovery restored `** IPFS Cluster is READY **`, rejoined the pool, same peerID.
- Applied Fix 1 on-device: blox-ai reads identity via the new path, healthy.
- Verified propagation: fxsupport image -> `docker cp` -> `/usr/bin/fula` -> `install.sh` refreshes the active compose on boot.

## Notes
No fleet deploy happens on merge -- CI builds `fxsupport:release` only when a GitHub Release is published. Ship Fix 1 + Fix 2 together (self-heal alone could re-wedge without the mount fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
