### PR TITLE
ci: pin QEMU binfmt for the arm64 cross-build (pre-empt the blox-ai segfault)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Pull Watchtower Docker Image
@@ -86,7 +86,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Pull Kubo Docker Image
@@ -147,7 +147,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fxsupport
@@ -176,7 +176,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build go-fula
@@ -207,7 +207,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build ipfs-cluster
@@ -240,7 +240,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fula-pinning
@@ -269,7 +269,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fula-gateway
@@ -299,7 +299,7 @@ jobs:
           # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
           # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
           # Pin a validated QEMU so the cross-build is reproducible.
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Tag all images for release

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Pull Watchtower Docker Image
@@ -69,6 +78,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Pull Kubo Docker Image
@@ -121,6 +139,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fxsupport
@@ -141,6 +168,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build go-fula
@@ -163,6 +199,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build ipfs-cluster
@@ -187,6 +232,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fula-pinning
@@ -207,6 +261,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build fula-gateway
@@ -228,6 +291,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_TOKEN }}
+      - name: Set up QEMU (pinned binfmt — avoids the arm64 dpkg/libc-bin QEMU segfault)
+        uses: docker/setup-qemu-action@v3
+        with:
+          # ARCH_SUPPORT is linux/arm64-only, so every image is cross-built under
+          # QEMU on the amd64 runner. The runner's default binfmt can segfault
+          # ("qemu: uncaught target signal 11") emulating arm64 dpkg/libc-bin in
+          # the fula-gateway apt-get layer (same failure blox-ai hit 2026-06-18).
+          # Pin a validated QEMU so the cross-build is reproducible.
+          image: tonistiigi/binfmt:latest
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Tag all images for release


### PR DESCRIPTION
## Why
`ARCH_SUPPORT="linux/arm64"` — every image is cross-built under QEMU emulation on the amd64 runner. This workflow had **no `setup-qemu-action`** and relied on the runner's default binfmt.

On 2026-06-18 the sibling repo **blox-ai** (which *does* use `setup-qemu-action`) failed its arm64 build with `qemu: uncaught target signal 11 (Segmentation fault)` while `dpkg` ran `libc-bin`'s post-install during `apt-get install` — a QEMU emulation regression (the same Dockerfile was green weeks earlier). `fula-gateway`'s Dockerfile does the **same Debian `apt-get install`**, so fula-ota's release build is at risk of the identical crash.

## What
Add `docker/setup-qemu-action@v3` pinned to `tonistiigi/binfmt:latest` ahead of buildx in every job. This pin is **validated** — it took blox-ai's arm64 build from red to green (the `libc-bin` trigger processed cleanly under it).

## Honest caveat
fula-ota's last release build was green on **2026-06-01** using the runner's default QEMU — a *different* QEMU source from blox-ai's `setup-qemu-action` binfmt. So this is **defensive**: fula-ota might not have hit the bug, but the `apt-get` pattern is identical and the pin is low-risk (a known-good QEMU + standard practice for arm64 cross-builds). Recommend merging **before** the next release build so a rebuild doesn't risk a second red build.

`:latest` is a moving tag; pin a specific `qemu-vX.Y.Z` if reproducibility is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
